### PR TITLE
can destructure the require's load now

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rss-to-json",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Rss to Json: RSS and Atom feed generator for Node.js",
   "author": {
     "name": "Nasa8x",

--- a/src/rss.js
+++ b/src/rss.js
@@ -7,7 +7,6 @@ var util = require('util'),
 
 module.exports = {
   load: function (url, callback) {
-    var $ = this;
     request({
       url: url,
       headers: {
@@ -25,7 +24,7 @@ module.exports = {
         });
         parser.parseString(xml, function (err, result) {
 
-          callback(null, $.parser(result));
+          callback(null, _parser(result));
           //console.log(JSON.stringify(result.rss.channel));
         });
 
@@ -35,102 +34,104 @@ module.exports = {
     });
 
   },
-  parser: function (json) {
-    var channel = json.rss.channel;
-    var rss = { items: [] };
-    if (util.isArray(json.rss.channel))
-      channel = json.rss.channel[0];
-
-    if (channel.title) {
-      rss.title = channel.title[0];
-    }
-    if (channel.description) {
-      rss.description = channel.description[0];
-    }
-    if (channel.link) {
-      rss.url = channel.link[0];
-    }
-
-    // add rss.image via @dubyajaysmith
-    if (channel.image) {
-      rss.image = channel.image[0].url
-    }
-
-    if (!rss.image && channel["itunes:image"]) {
-      rss.image = channel['itunes:image'][0].href
-    }
-
-    rss.image = rss.image && Array.isArray(rss.image) ? rss.image[0] : '';
-
-    if (channel.item) {
-      if (!util.isArray(channel.item)) {
-        channel.item = [channel.item];
-      }
-      channel.item.forEach(function (val) {
-        var obj = {};
-        obj.title = !util.isNullOrUndefined(val.title) ? val.title[0] : '';
-        obj.description = !util.isNullOrUndefined(val.description) ? val.description[0] : '';
-        obj.url = obj.link = !util.isNullOrUndefined(val.link) ? val.link[0] : '';
-
-        if (val['itunes:subtitle']) {
-          obj.itunes_subtitle = val['itunes:subtitle'][0];
-        }
-        if (val['itunes:summary']) {
-          obj.itunes_summary = val['itunes:summary'][0];
-        }
-        if (val['itunes:author']) {
-          obj.itunes_author = val['itunes:author'][0];
-        }
-        if (val['itunes:explicit']) {
-          obj.itunes_explicit = val['itunes:explicit'][0];
-        }
-        if (val['itunes:duration']) {
-          obj.itunes_duration = val['itunes:duration'][0];
-        }
-        if (val['itunes:season']) {
-          obj.itunes_season = val['itunes:season'][0];
-        }
-        if (val['itunes:episode']) {
-          obj.itunes_episode = val['itunes:episode'][0];
-        }
-        if (val['itunes:episodeType']) {
-          obj.itunes_episodeType = val['itunes:episodeType'][0];
-        }
-        if (val.pubDate) {
-          //lets try basis js date parsing for now
-          obj.created = Date.parse(val.pubDate[0]);
-        }
-        if (val['media:content']) {
-          obj.media = val.media || {};
-          obj.media.content = val['media:content'];
-        }
-        if (val['media:thumbnail']) {
-          obj.media = val.media || {};
-          obj.media.thumbnail = val['media:thumbnail'];
-        }
-        if (val.enclosure) {
-          obj.enclosures = [];
-          if (!util.isArray(val.enclosure))
-            val.enclosure = [val.enclosure];
-          val.enclosure.forEach(function (enclosure) {
-            var enc = {};
-            for (var x in enclosure) {
-              enc[x] = enclosure[x][0];
-            }
-            obj.enclosures.push(enc);
-          });
-
-        }
-        rss.items.push(obj);
-
-      });
-
-    }
-    return rss;
-
-  },
+  parser: _parser,
   read: function (url, callback) {
     return this.load(url, callback);
   }
 
 };
+
+function _parser(json) {
+  var channel = json.rss.channel;
+  var rss = { items: [] };
+  if (util.isArray(json.rss.channel))
+    channel = json.rss.channel[0];
+
+  if (channel.title) {
+    rss.title = channel.title[0];
+  }
+  if (channel.description) {
+    rss.description = channel.description[0];
+  }
+  if (channel.link) {
+    rss.url = channel.link[0];
+  }
+
+  // add rss.image via @dubyajaysmith
+  if (channel.image) {
+    rss.image = channel.image[0].url
+  }
+
+  if (!rss.image && channel["itunes:image"]) {
+    rss.image = channel['itunes:image'][0].href
+  }
+
+  rss.image = rss.image && Array.isArray(rss.image) ? rss.image[0] : '';
+
+  if (channel.item) {
+    if (!util.isArray(channel.item)) {
+      channel.item = [channel.item];
+    }
+    channel.item.forEach(function (val) {
+      var obj = {};
+      obj.title = !util.isNullOrUndefined(val.title) ? val.title[0] : '';
+      obj.description = !util.isNullOrUndefined(val.description) ? val.description[0] : '';
+      obj.url = obj.link = !util.isNullOrUndefined(val.link) ? val.link[0] : '';
+
+      if (val['itunes:subtitle']) {
+        obj.itunes_subtitle = val['itunes:subtitle'][0];
+      }
+      if (val['itunes:summary']) {
+        obj.itunes_summary = val['itunes:summary'][0];
+      }
+      if (val['itunes:author']) {
+        obj.itunes_author = val['itunes:author'][0];
+      }
+      if (val['itunes:explicit']) {
+        obj.itunes_explicit = val['itunes:explicit'][0];
+      }
+      if (val['itunes:duration']) {
+        obj.itunes_duration = val['itunes:duration'][0];
+      }
+      if (val['itunes:season']) {
+        obj.itunes_season = val['itunes:season'][0];
+      }
+      if (val['itunes:episode']) {
+        obj.itunes_episode = val['itunes:episode'][0];
+      }
+      if (val['itunes:episodeType']) {
+        obj.itunes_episodeType = val['itunes:episodeType'][0];
+      }
+      if (val.pubDate) {
+        //lets try basis js date parsing for now
+        obj.created = Date.parse(val.pubDate[0]);
+      }
+      if (val['media:content']) {
+        obj.media = val.media || {};
+        obj.media.content = val['media:content'];
+      }
+      if (val['media:thumbnail']) {
+        obj.media = val.media || {};
+        obj.media.thumbnail = val['media:thumbnail'];
+      }
+      if (val.enclosure) {
+        obj.enclosures = [];
+        if (!util.isArray(val.enclosure))
+          val.enclosure = [val.enclosure];
+        val.enclosure.forEach(function (enclosure) {
+          var enc = {};
+          for (var x in enclosure) {
+            enc[x] = enclosure[x][0];
+          }
+          obj.enclosures.push(enc);
+        });
+
+      }
+      rss.items.push(obj);
+
+    });
+
+  }
+  return rss;
+
+}


### PR DESCRIPTION
I pulled the module's anonymous parser function into a named function and then referenced that inside the load function rather than using the `$=this` method. The latter breaks when you try

    const {load} = require('rss-to-json')

but it works with the method I used. And since it's possible the user might only need to use `load` and never import `parser` or `reader`, I figured why not?

Also `this` varies in what it means depending on whether you're using strict mode or not (and if you use `new` by mistake), which just gives me the heebyjeebies :)

Because this technically changes the topology of the module by adding a new feature (but not breaking anything else), I bumped the version from 1.0.3 to 1.1.0 as per my understanding of semantic versioning.