### PR TITLE
Fixing problem when we receive an non-RSS XML after parsing

### DIFF
--- a/src/rss.js
+++ b/src/rss.js
@@ -24,9 +24,12 @@ module.exports = {
           callback(err, null);
         });
         parser.parseString(xml, function (err, result) {
-
-          callback(null, $.parser(result));
-          //console.log(JSON.stringify(result.rss.channel));
+          if (result.rss) {
+            callback(null, $.parser(result));
+            //console.log(JSON.stringify(result.rss.channel));
+          } else {
+            callback({'error': 'This is not an RSS feed'});
+          }
         });
 
       } else {


### PR DESCRIPTION
Today one of the RSS feeds  I was monitoring went down and produced an HTML error page. That one got parsed and was sent to $.parser - which broke on the json.rss.channel ... and actually brought the whole application down. Here is a simple fix that checks whether there is results.rss before going to parser.