### PR TITLE
Added created key to rss items and modified updated.

### DIFF
--- a/src/rss.js
+++ b/src/rss.js
@@ -94,7 +94,8 @@ module.exports = {
         obj.url = val.link && val.link.href ? val.link.href : val.link;
         obj.link = obj.url;
         obj.author = val.author && val.author.name ? val.author.name : val['dc:creator'];
-        obj.created = val.updated ? Date.parse(val.updated) : val.pubDate ? Date.parse(val.pubDate) : Date.now;
+        obj.published = val.created ? Date.parse(val.created) : val.pubDate ? Date.parse(val.pubDate) : Date.now();
+        obj.created = val.updated ? Date.parse(val.updated) : val.pubDate ? Date.parse(val.pubDate) : val.created ? Date.parse(val.created) : Date.now;
         obj.category = val.category || [];
         obj.content = val.content && val.content.$t ? val.content.$t : null;
 


### PR DESCRIPTION
Added published key to rss item that holds date when the item was initially created, and added rss created tag to created key.

The created rss tag is used by YouTube and probably some other services as well.

The new published key allows access to the date the item was originally created regardless of if or when it was updated.