### PR TITLE
Add last update of rss/atom

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -23,6 +23,7 @@ export default async (url: string, config: AxiosRequestConfig) => {
         link: channel.link && channel.link.href ? channel.link.href : channel.link,
         image: channel.image ? channel.image.url : channel["itunes:image"] ? channel['itunes:image'].href : '',
         category: channel.category || [],
+        updated: channel.lastBuildDate || channel.updated || '',
         items: []
     };
 


### PR DESCRIPTION
I found it is important to track when the feed last updated at. 
This PR just add new key `updated` to the rss object.

Feel free to accept or drop this, cheers :beers:  