### PR TITLE
entry and items might not exist, default to an empty array

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -26,7 +26,7 @@ export default async (url: string, config: AxiosRequestConfig) => {
         items: []
     };
 
-    let items = channel.item || channel.entry;
+    let items = channel.item || channel.entry || [];
     if (items && !Array.isArray(items)) items = [items];
 
 


### PR DESCRIPTION
This fixes: https://github.com/nasa8x/rss-to-json/issues/38 by defaulting the entry/item expected on channel to be an empty array if entry or item does not exist on channel as seen in an RSS feed like:

```
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0">
  <channel>
    <title><![CDATA[Amazon API Gateway (London) Service Status]]></title>
    <link>http://status.aws.amazon.com/</link>
    <language>en-us</language>
    <lastBuildDate>Fri, 17 Dec 2021 00:05:40 PST</lastBuildDate>
    <generator>AWS Service Health Dashboard RSS Generator</generator>
    <description><![CDATA[Amazon API Gateway (London) Service Status]]></description>
    <ttl>5</ttl>
    <!-- You seem to care about knowing about your events, why not check out https://docs.aws.amazon.com/health/latest/ug/getting-started-api.html -->

	
  </channel>
</rss>
```